### PR TITLE
doc(flags): add Kenyan flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ### Contributors Country Flags
 <kbd><img title="Nigeria" alt="Nigeria" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ng.svg" width="22"></kbd>
 <kbd><img title="Uganda" alt="Uganda" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ug.svg" width="22"></kbd>
+<kbd><img title="Kenya"   alt="Kenya flag"   src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ke.svg" width="22"></kbd>
 
 This is a project for you to practice contributing to open source projects with code.
 


### PR DESCRIPTION
## Summary

This PR adds the Kenyan flag icon to the **Contributors Country Flags** section of the README.

## Rationale

Including Kenya alongside the existing flags (Nigeria, Uganda) accurately reflects the project’s contributor base and maintains consistency in the documentation’s international representation.


- [ ] I have added a screenshot from browser with my changes
- [x] Documentation only
- [x] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
