### PR TITLE
docs(flags): add Tanzanian flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 <kbd><img title="Benin"   alt="Benin"   src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/bj.svg" width="22"></kbd>
 <kbd><img title="Brazil"   alt="Brazil"   src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/br.svg" width="22"></kbd>
 
+<kbd><img title="Tanzania" alt="Tanzania flag" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/tz.svg" width="22"></kbd>
+
 This is a project for you to practice contributing to open source projects with code.
 
 We're assuming that you've already finished the tutorial at [first open source contributions](https://github.com/btrust-builders/first-open-source-contributions)


### PR DESCRIPTION
This PR adds the Tanzanian flag icon to the **Contributors Country Flags** section of the README.

## Rationale

Including Tanzania alongside the existing contributor flags ensures all represented countries are displayed consistently and accessibly.

- [X] There are no errors in the console

