### PR TITLE
Add Akpahsamuel contributor card

### DIFF
--- a/contributors/Akpahsamuel.html
+++ b/contributors/Akpahsamuel.html
@@ -1,0 +1,40 @@
+<article>
+  <h3>Samuel Akpah</h3>
+  <p>Open-source contributor & Bitcoin builder from Ghana 🇬🇭⚡ Passionate about decentralization, clean code, and building for impact.</p>
+
+  <h4>Languages I’m using for Bitcoin dev</h4>
+  <section class="container">
+    <div class="badge" style="background-color: #f7931a; color: black;">Rust</div>
+    <div class="badge" style="background-color: #306998; color: white;">Python</div>
+    <div class="badge" style="background-color: #000000; color: white;">JavaScript</div>
+    <div class="badge" style="background-color: #3178c6; color: white;">TypeScript</div>
+    <div class="badge" style="background-color: #555555; color: white;">Shell</div>
+  </section>
+
+  <h4>Tools I use</h4>
+  <section class="container">
+    <img class="icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" />
+    <img class="icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" />
+    <img class="icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-original.svg" />
+    <img class="icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/bash/bash-original.svg" />
+    <img class="icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" />
+  </section>
+</article>
+
+<style>
+  body {
+    font-family: sans-serif;
+  }
+  .container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+  .badge {
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+  }
+  .icon {
+    width: 2rem;
+  }
+</style>


### PR DESCRIPTION
## Add Akpahsamuel contributor card

Adds my contributor card at `contributors/Akpahsamuel.html` as part of the open-source contribution tutorial.

**What's in the card:**
- Name, short bio
- Languages: Rust, Python, JavaScript, TypeScript, Shell
- Tools: TypeScript, Git, Linux, Bash, VS Code

### Checklist

- [ ] I have added a screenshot from browser with my changes
- [x] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.

### Things I'd improve in the tutorial

1. **`CONTRIBUTING.md` is out of date about how cards load.** It says to manually add your filename to `scripts/contributors.js`, but that file is now auto-generated by `scripts/generate-cards.sh` and is gitignored. On a fresh clone `contributors.js` doesn't exist, so opening `index.html` shows no cards until you run `bash scripts/generate-cards.sh`. The docs should replace the manual-edit step with running that script, and mention it before the "preview in browser" step.
2. **The card template has a broken image.** The template references `icons/bitcoin/bitcoin-original.svg`, which doesn't exist in devicon (404 → broken-image icon). I left it out of my card for this reason.
3. **The clone step assumes SSH.** HTTPS would be a gentler default for first-time contributors who haven't set up SSH keys yet.
